### PR TITLE
callback jsonData set for empty JSON object if no data is provided

### DIFF
--- a/src/android/com/plugin/gcm/OneSignalPush.java
+++ b/src/android/com/plugin/gcm/OneSignalPush.java
@@ -69,12 +69,18 @@ public class OneSignalPush extends CordovaPlugin {
   
   // This is to prevent an issue where if two Javascript calls are made to OneSignal expecting a callback then only one would fire.
   private static void callbackSuccess(CallbackContext callbackContext, JSONObject jsonObject) {
+    if(jsonObject == null){ // in case there are no data
+      jsonObject = new JSONObject();
+    }
     PluginResult pluginResult = new PluginResult(PluginResult.Status.OK, jsonObject);
     pluginResult.setKeepCallback(true);
     callbackContext.sendPluginResult(pluginResult);
   }
   
   private static void callbackError(CallbackContext callbackContext, JSONObject jsonObject) {
+    if(jsonObject == null){ // in case there are no data
+      jsonObject = new JSONObject();
+    }
     PluginResult pluginResult = new PluginResult(PluginResult.Status.ERROR, jsonObject);
     pluginResult.setKeepCallback(true);
     callbackContext.sendPluginResult(pluginResult);


### PR DESCRIPTION
If user has no tags the Android cordova plugin has exception in PluginResult constructor. It breaks communication with javascript code in getTags() method.